### PR TITLE
SUP-202 | Add top spacing for no search results message

### DIFF
--- a/src/components/algolia-search/algolia-search-form.tsx
+++ b/src/components/algolia-search/algolia-search-form.tsx
@@ -326,7 +326,7 @@ const HitList = ({searchIndex}: {searchIndex: string}) => {
   }, [sortBy, searchIndex, query])
 
   if (hits.length === 0) {
-    return <p>No results for your search. Please try another search.</p>
+    return <p className="rs-mt-6">No results for your search. Please try another search.</p>
   }
 
   return (


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add top spacing for no search results message

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to search page and search for `nosearchresults`
4. Verify that the no results message appears as Kerri outlined in the JIRA ticket:
![image](https://github.com/user-attachments/assets/06dd45fb-a107-4ea2-9fdb-857c0505cf87)

5. Review code


# Associated Issues and/or People
- SUP-202