### PR TITLE
SUP-188 | Adjust basic page heading display for full width

### DIFF
--- a/src/components/nodes/pages/stanford-page/stanford-page-page.tsx
+++ b/src/components/nodes/pages/stanford-page/stanford-page-page.tsx
@@ -6,6 +6,7 @@ import {NodeStanfordPage} from "@lib/gql/__generated__/drupal.d"
 import BannerParagraph from "@components/paragraphs/stanford-banner/banner-paragraph"
 import PageTitleBannerParagraph from "@components/paragraphs/stanford-page-title-banner/page-title-banner-paragraph"
 import SupCarouselParagraph from "@components/paragraphs/sup-carousel/sup-carousel-paragraph"
+import clsx from "clsx"
 
 type Props = HtmlHTMLAttributes<HTMLDivElement> & {
   node: NodeStanfordPage
@@ -30,7 +31,7 @@ const StanfordPagePage = ({node, ...props}: Props) => {
       )}
 
       {node.suPageBanner?.__typename !== "ParagraphStanfordPageTitleBanner" && (
-        <H1 className="centered mt-32">{node.title}</H1>
+        <H1 className={clsx("centered mt-32", {"lg:max-w-1200": fullWidth})}>{node.title}</H1>
       )}
 
       {!fullWidth && (


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adjust basic page heading display for full width

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Create a basic page with a text are paragraph, a layout set to full width, and add it to the menu
3. Navigate to page and confirm that the subnav doesn't display and heading aligns with WYSIWYG text
4. Create a basic page with a text are paragraph and add it to the menu
5. Navigate to page and confirm the heading appears aligned with the subnav
6. Create a basic page with a text are paragraph 
7. Navigate to page and confirm that the heading aligns with the WYSWIYG test
8. Review code

# Associated Issues and/or People
- SUP-188
