### PR TITLE
SUP-278 | adjust page title banner height

### DIFF
--- a/src/components/paragraphs/stanford-page-title-banner/page-title-banner-paragraph.tsx
+++ b/src/components/paragraphs/stanford-page-title-banner/page-title-banner-paragraph.tsx
@@ -16,7 +16,7 @@ const PageTitleBannerParagraph = ({paragraph, pageTitle, ...props}: Props) => {
     <div
       {...props}
       className={twMerge(
-        "rs-mb-7 flex min-h-[200px] flex-col items-center @container md:min-h-[400px]",
+        "rs-mb-7 flex min-h-[200px] flex-col items-center @container md:min-h-[250px]",
         props.className
       )}
     >


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- adjust page title banner height

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Navigate to Books page on preview site
4. Verify that the banner is min 250px
5. Review code

# Associated Issues and/or People
- SUP-278
- SUP-215