### PR TITLE
SUP-215 | add regex to resolve typography bug, revert header logo due to alignment issues

### DIFF
--- a/src/components/elements/action-link.tsx
+++ b/src/components/elements/action-link.tsx
@@ -8,7 +8,7 @@ const ActionLink = ({children, className, ...props}: LinkProps) => {
     <Link
       {...props}
       className={twMerge(
-        "relative",
+        "relative flex w-fit items-center",
         clsx({
           "group text-digital-red hocus:text-archway-dark": !className?.includes("button"),
         }),
@@ -16,10 +16,7 @@ const ActionLink = ({children, className, ...props}: LinkProps) => {
       )}
     >
       {children}
-      <ArrowLongRightIcon
-        height={20}
-        className="mb-2 ml-2 inline-block text-digital-red group-hocus:text-archway-dark"
-      />
+      <ArrowLongRightIcon height={20} className="ml-2 text-digital-red group-hocus:text-archway-dark" />
     </Link>
   )
 }

--- a/src/components/elements/headers.tsx
+++ b/src/components/elements/headers.tsx
@@ -11,7 +11,7 @@ export const H1 = ({children, className, ...props}: Props) => {
       {...props}
       className={twMerge(
         "rs-mb-5 font-medium",
-        className?.match(/(type-|text-)/) ? className : ["type-3 xl:text-[4.1rem]", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-3 xl:text-[4.1rem]", className]
       )}
     >
       {children}
@@ -26,7 +26,7 @@ export const H2 = ({children, className, ...props}: Props) => {
       className={twMerge(
         headingLinkClasses,
         "font-medium",
-        className?.match(/(type-|text-)/) ? className : ["type-2 xl:text-[3.3rem]", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-2 xl:text-[3.3rem]", className]
       )}
     >
       {children}
@@ -41,7 +41,7 @@ export const H3 = ({children, className, ...props}: Props) => {
       className={twMerge(
         headingLinkClasses,
         "font-medium",
-        className?.match(/(type-|text-)/) ? className : ["type-1 xl:text-26", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-1 xl:text-26", className]
       )}
     >
       {children}
@@ -56,7 +56,7 @@ export const H4 = ({children, className, ...props}: Props) => {
       className={twMerge(
         headingLinkClasses,
         "font-bold",
-        className?.match(/(type-|text-)/) ? className : ["type-0 xl:text-21", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-0 xl:text-21", className]
       )}
     >
       {children}
@@ -71,7 +71,7 @@ export const H5 = ({children, className, ...props}: Props) => {
       className={twMerge(
         headingLinkClasses,
         "font-medium",
-        className?.match(/(type-|text-)/) ? className : ["type-0 xl:text-21", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-0 xl:text-21", className]
       )}
     >
       {children}
@@ -86,7 +86,7 @@ export const H6 = ({children, className, ...props}: Props) => {
       className={twMerge(
         headingLinkClasses,
         "font-medium",
-        className?.match(/(type-|text-)/) ? className : ["type-0 xl:text-21", className]
+        className?.match(/type-\btext-\d+\b/g) ? className : ["type-0 xl:text-21", className]
       )}
     >
       {children}

--- a/src/components/elements/wysiwyg.tsx
+++ b/src/components/elements/wysiwyg.tsx
@@ -155,7 +155,7 @@ const fixClasses = (classes?: string | boolean): string => {
 
   classes = classes
     .replaceAll(" su-", " ")
-    .replaceAll(" text-align-center ", " text-center ")
+    .replaceAll(" text-align-center ", " text-center *:mx-auto ")
     .replace(" text-align-right ", " text-right ")
     .replaceAll(" align-center ", " mx-auto ")
     .replaceAll(" align-left ", " float-left mr-10 mb-10 ")

--- a/src/components/global/page-header.tsx
+++ b/src/components/global/page-header.tsx
@@ -15,7 +15,7 @@ const PageHeader = async () => {
       <GlobalMessage />
       <div className="min-h-50 relative z-[2] border-b border-fog">
         <div className="grow-1 centered flex items-center justify-between gap-20 pr-24 lg:pr-0">
-          <div className="rs-pt-0 rs-pb-1 w-full lg:rs-pt-1 lg:rs-pb-2">
+          <div className="rs-pt-0 rs-pb-1 lg:rs-pt-1 lg:rs-pb-2">
             <Link
               href="/"
               className="flex flex-col gap-4 no-underline lg:flex-row"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUP-215 | add regex to resolve typography bug, revert header logo due to alignment issues

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Review home page and confirm that the text/type fonts are being properly applied to the Blog teasers and About section 
2. Review code

# Associated Issues and/or People
- SUP-215
