### PR TITLE
SUP-270 SUP-295 | add fixed widths to header logo and fix desk buttons

### DIFF
--- a/src/components/elements/link.tsx
+++ b/src/components/elements/link.tsx
@@ -4,7 +4,7 @@ import {EnvelopeIcon} from "@heroicons/react/24/outline"
 import ActionLink from "@components/elements/action-link"
 import Button from "@components/elements/button"
 import {LinkProps as NextLinkProps} from "next/dist/client/link"
-import {twMerge} from "tailwind-merge"
+import twMerge from "@lib/utils/twMergeConfig"
 
 export type LinkProps = HtmlHTMLAttributes<HTMLAnchorElement | HTMLButtonElement> &
   NextLinkProps & {

--- a/src/components/elements/link.tsx
+++ b/src/components/elements/link.tsx
@@ -4,7 +4,7 @@ import {EnvelopeIcon} from "@heroicons/react/24/outline"
 import ActionLink from "@components/elements/action-link"
 import Button from "@components/elements/button"
 import {LinkProps as NextLinkProps} from "next/dist/client/link"
-import {twMerge} from "tailwind-merge"
+import clsx from "clsx"
 
 export type LinkProps = HtmlHTMLAttributes<HTMLAnchorElement | HTMLButtonElement> &
   NextLinkProps & {
@@ -51,7 +51,7 @@ const DrupalLink = ({href, children, ...props}: LinkProps) => {
   }
 
   return (
-    <Link {...props} href={href} className={twMerge("group text-digital-red hocus:text-archway-dark", props.className)}>
+    <Link {...props} href={href} className={clsx("group text-digital-red hocus:text-archway-dark", props.className)}>
       {children}
       {href.startsWith("mailto") && (
         <EnvelopeIcon width={20} className="ml-4 inline-block text-digital-red group-hocus:text-archway-dark" />

--- a/src/components/elements/link.tsx
+++ b/src/components/elements/link.tsx
@@ -4,7 +4,7 @@ import {EnvelopeIcon} from "@heroicons/react/24/outline"
 import ActionLink from "@components/elements/action-link"
 import Button from "@components/elements/button"
 import {LinkProps as NextLinkProps} from "next/dist/client/link"
-import clsx from "clsx"
+import {twMerge} from "tailwind-merge"
 
 export type LinkProps = HtmlHTMLAttributes<HTMLAnchorElement | HTMLButtonElement> &
   NextLinkProps & {
@@ -51,7 +51,7 @@ const DrupalLink = ({href, children, ...props}: LinkProps) => {
   }
 
   return (
-    <Link {...props} href={href} className={clsx("group text-digital-red hocus:text-archway-dark", props.className)}>
+    <Link {...props} href={href} className={twMerge("group text-digital-red hocus:text-archway-dark", props.className)}>
       {children}
       {href.startsWith("mailto") && (
         <EnvelopeIcon width={20} className="ml-4 inline-block text-digital-red group-hocus:text-archway-dark" />

--- a/src/components/images/header-logo-lg.tsx
+++ b/src/components/images/header-logo-lg.tsx
@@ -15,7 +15,7 @@ const HeaderLogoLg = (props: Props) => {
 
   return (
     <svg
-      className="h-auto w-full lg:h-[84px]"
+      className="h-auto w-[400px] lg:w-[450px] 2xl:w-[700px]"
       width="100%"
       height="100%"
       viewBox="0 0 705 87"

--- a/src/components/images/header-logo-lg.tsx
+++ b/src/components/images/header-logo-lg.tsx
@@ -15,7 +15,7 @@ const HeaderLogoLg = (props: Props) => {
 
   return (
     <svg
-      className="h-auto w-[400px] lg:w-[450px] 2xl:w-[700px]"
+      className="h-auto w-[400px] lg:w-[356px] xl:w-[476px] 2xl:w-[700px]"
       width="100%"
       height="100%"
       viewBox="0 0 705 87"

--- a/src/components/nodes/pages/sup-book/book-page/book-page.tsx
+++ b/src/components/nodes/pages/sup-book/book-page/book-page.tsx
@@ -198,7 +198,7 @@ const BookPage = async ({node, ...props}: Props) => {
 
             <Link
               href={node.path + "/desk-examination-copy-requests"}
-              className="flex items-start gap-3 text-18 font-normal leading-snug text-stone-dark underline-offset-[5px] hocus:text-archway-dark hocus:decoration-archway-dark hocus:decoration-2"
+              className="flex items-start gap-3 text-[1.8rem] font-normal leading-snug text-stone-dark underline-offset-[5px] hocus:text-archway-dark hocus:decoration-archway-dark hocus:decoration-2"
             >
               <ClipboardIcon width={24} className="mt-1 shrink-0 text-fog-dark" /> Desk, Examination, or Review Copy
               Requests

--- a/src/components/nodes/pages/sup-book/book-page/book-page.tsx
+++ b/src/components/nodes/pages/sup-book/book-page/book-page.tsx
@@ -198,7 +198,7 @@ const BookPage = async ({node, ...props}: Props) => {
 
             <Link
               href={node.path + "/desk-examination-copy-requests"}
-              className="flex items-start gap-3 text-[1.8rem] font-normal leading-snug text-stone-dark underline-offset-[5px] hocus:text-archway-dark hocus:decoration-archway-dark hocus:decoration-2"
+              className="flex items-start gap-3 text-18 font-normal leading-snug text-stone-dark underline-offset-[5px] hocus:text-archway-dark hocus:decoration-archway-dark hocus:decoration-2"
             >
               <ClipboardIcon width={24} className="mt-1 shrink-0 text-fog-dark" /> Desk, Examination, or Review Copy
               Requests

--- a/src/lib/utils/twMergeConfig.tsx
+++ b/src/lib/utils/twMergeConfig.tsx
@@ -1,0 +1,18 @@
+import {extendTailwindMerge} from "tailwind-merge"
+
+// Creates an array containing type-# classes from 0 to 1
+const typeClasses = Array.from({length: 10}, (_, i) => `type-${i}`)
+// Creates an array containing text-# classes from 11 to 30
+const textClasses = Array.from({length: 20}, (_, i) => `text-${i + 11}`)
+
+const typographyClasses = [...textClasses, ...typeClasses]
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": typographyClasses,
+    },
+  },
+})
+
+export default twMerge


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SUP-270 SUP-295 | add fixed widths to header logo and fix desk buttons

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Navigate to...
4. Verify...

# Associated Issues and/or People
- SUP-270
- SUP-295
